### PR TITLE
Fix for args not using camel case in path

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -49,7 +49,7 @@ function parseMethods({paths, security, parameters}: Swagger): Method[] {
           methodType: methodType.toUpperCase() as MethodType,
           parameters: transformParameters(operation.parameters, parameters || {}),
           // tslint:disable-next-line:no-invalid-template-strings
-          path: pathName.replace(/{(.*?)}/g, '$${args.$1}'), // turn path interpolation `{this}` into string template `${this}
+          path: pathName.replace(/{(.*?)}/g, (substring: string, ...args: any[]): string => '${args.' + camelCase(args[0]) + '}' ), // turn path interpolation `{this}` into string template `${this}
           response: prefixImportedModels(determineResponseType(operation.responses)),
           summaryLines: operation.description
             ? (operation.description || '').split('\n')

--- a/tests/github/api/api-client.service.ts
+++ b/tests/github/api/api-client.service.ts
@@ -7120,7 +7120,7 @@ export class APIClient {
     },
     options?: HttpOptions
   ): Observable<any> {
-    const path = `/repos/${args.owner}/${args.repo}/${args.archive_format}/${args.path}`;
+    const path = `/repos/${args.owner}/${args.repo}/${args.archiveFormat}/${args.path}`;
     options = {...this.options, ...options};
 
     if ('xGitHubMediaType' in args) {


### PR DESCRIPTION
closes #42 

This resolves the issue with incorrect case used in paths. There is an example of the issue in the github api.