### PR TITLE
fix(api-client): throwError instead of deprecated Observable.throw

### DIFF
--- a/templates/ngx-service.mustache
+++ b/templates/ngx-service.mustache
@@ -2,7 +2,7 @@
 
 import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { Inject, Injectable, InjectionToken, Optional } from '@angular/core';
-import { Observable } from 'rxjs';
+import { Observable, throwError } from 'rxjs';
 import { DefaultHttpOptions, HttpOptions } from './';
 
 {{#definitions.length}}
@@ -27,7 +27,7 @@ export class APIClient {
 
   private readonly domain: string = `{{&domain}}`;
 
-  constructor(private http: HttpClient,
+  constructor(private readonly http: HttpClient,
               @Optional() @Inject(USE_DOMAIN) domain: string,
               @Optional() @Inject(USE_HTTP_OPTIONS) options: DefaultHttpOptions) {
 
@@ -105,7 +105,7 @@ export class APIClient {
         return this.http.put<T>(`${this.domain}${path}`, body, options);
       default:
         console.error(`Unsupported request: ${method}`);
-        return Observable.throw(`Unsupported request: ${method}`);
+        return throwError(`Unsupported request: ${method}`);
     }
   }
 }

--- a/tests/custom/api/api-client.service.ts
+++ b/tests/custom/api/api-client.service.ts
@@ -2,7 +2,7 @@
 
 import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { Inject, Injectable, InjectionToken, Optional } from '@angular/core';
-import { Observable } from 'rxjs';
+import { Observable, throwError } from 'rxjs';
 import { DefaultHttpOptions, HttpOptions } from './';
 
 import * as models from './models';
@@ -25,7 +25,7 @@ export class APIClient {
 
   private readonly domain: string = `//${window.location.hostname}${window.location.port ? ':'+window.location.port : ''}`;
 
-  constructor(private http: HttpClient,
+  constructor(private readonly http: HttpClient,
               @Optional() @Inject(USE_DOMAIN) domain: string,
               @Optional() @Inject(USE_HTTP_OPTIONS) options: DefaultHttpOptions) {
 
@@ -97,7 +97,7 @@ export class APIClient {
         return this.http.put<T>(`${this.domain}${path}`, body, options);
       default:
         console.error(`Unsupported request: ${method}`);
-        return Observable.throw(`Unsupported request: ${method}`);
+        return throwError(`Unsupported request: ${method}`);
     }
   }
 }

--- a/tests/esquare/api/api-client.service.ts
+++ b/tests/esquare/api/api-client.service.ts
@@ -2,7 +2,7 @@
 
 import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { Inject, Injectable, InjectionToken, Optional } from '@angular/core';
-import { Observable } from 'rxjs';
+import { Observable, throwError } from 'rxjs';
 import { DefaultHttpOptions, HttpOptions } from './';
 
 import * as models from './models';
@@ -25,7 +25,7 @@ export class APIClient {
 
   private readonly domain: string = `https://virtserver.swaggerhub.com/Esquare/EsquareAPI/1.0.0`;
 
-  constructor(private http: HttpClient,
+  constructor(private readonly http: HttpClient,
               @Optional() @Inject(USE_DOMAIN) domain: string,
               @Optional() @Inject(USE_HTTP_OPTIONS) options: DefaultHttpOptions) {
 
@@ -865,7 +865,7 @@ export class APIClient {
         return this.http.put<T>(`${this.domain}${path}`, body, options);
       default:
         console.error(`Unsupported request: ${method}`);
-        return Observable.throw(`Unsupported request: ${method}`);
+        return throwError(`Unsupported request: ${method}`);
     }
   }
 }

--- a/tests/gcloud-firestore/api/api-client.service.ts
+++ b/tests/gcloud-firestore/api/api-client.service.ts
@@ -2,7 +2,7 @@
 
 import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { Inject, Injectable, InjectionToken, Optional } from '@angular/core';
-import { Observable } from 'rxjs';
+import { Observable, throwError } from 'rxjs';
 import { DefaultHttpOptions, HttpOptions } from './';
 
 import * as models from './models';
@@ -25,7 +25,7 @@ export class APIClient {
 
   private readonly domain: string = `https://firestore.googleapis.com/v1beta1`;
 
-  constructor(private http: HttpClient,
+  constructor(private readonly http: HttpClient,
               @Optional() @Inject(USE_DOMAIN) domain: string,
               @Optional() @Inject(USE_HTTP_OPTIONS) options: DefaultHttpOptions) {
 
@@ -346,7 +346,7 @@ export class APIClient {
         return this.http.put<T>(`${this.domain}${path}`, body, options);
       default:
         console.error(`Unsupported request: ${method}`);
-        return Observable.throw(`Unsupported request: ${method}`);
+        return throwError(`Unsupported request: ${method}`);
     }
   }
 }

--- a/tests/github/api/api-client.service.ts
+++ b/tests/github/api/api-client.service.ts
@@ -2,7 +2,7 @@
 
 import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { Inject, Injectable, InjectionToken, Optional } from '@angular/core';
-import { Observable } from 'rxjs';
+import { Observable, throwError } from 'rxjs';
 import { DefaultHttpOptions, HttpOptions } from './';
 
 import * as models from './models';
@@ -25,7 +25,7 @@ export class APIClient {
 
   private readonly domain: string = `https://api.github.com`;
 
-  constructor(private http: HttpClient,
+  constructor(private readonly http: HttpClient,
               @Optional() @Inject(USE_DOMAIN) domain: string,
               @Optional() @Inject(USE_HTTP_OPTIONS) options: DefaultHttpOptions) {
 
@@ -9434,7 +9434,7 @@ export class APIClient {
         return this.http.put<T>(`${this.domain}${path}`, body, options);
       default:
         console.error(`Unsupported request: ${method}`);
-        return Observable.throw(`Unsupported request: ${method}`);
+        return throwError(`Unsupported request: ${method}`);
     }
   }
 }


### PR DESCRIPTION
closes #50 
