### PR TITLE
APIClient options property public -> private

### DIFF
--- a/templates/ngx-service.mustache
+++ b/templates/ngx-service.mustache
@@ -23,7 +23,7 @@ type APIHttpOptions = HttpOptions & {
 @Injectable()
 export class APIClient {
 
-  readonly options: APIHttpOptions;
+  private readonly options: APIHttpOptions;
 
   private readonly domain: string = `{{&domain}}`;
 

--- a/tests/custom/api/api-client.service.ts
+++ b/tests/custom/api/api-client.service.ts
@@ -21,7 +21,7 @@ type APIHttpOptions = HttpOptions & {
 @Injectable()
 export class APIClient {
 
-  readonly options: APIHttpOptions;
+  private readonly options: APIHttpOptions;
 
   private readonly domain: string = `//${window.location.hostname}${window.location.port ? ':'+window.location.port : ''}`;
 

--- a/tests/esquare/api/api-client.service.ts
+++ b/tests/esquare/api/api-client.service.ts
@@ -21,7 +21,7 @@ type APIHttpOptions = HttpOptions & {
 @Injectable()
 export class APIClient {
 
-  readonly options: APIHttpOptions;
+  private readonly options: APIHttpOptions;
 
   private readonly domain: string = `https://virtserver.swaggerhub.com/Esquare/EsquareAPI/1.0.0`;
 

--- a/tests/gcloud-firestore/api/api-client.service.ts
+++ b/tests/gcloud-firestore/api/api-client.service.ts
@@ -21,7 +21,7 @@ type APIHttpOptions = HttpOptions & {
 @Injectable()
 export class APIClient {
 
-  readonly options: APIHttpOptions;
+  private readonly options: APIHttpOptions;
 
   private readonly domain: string = `https://firestore.googleapis.com/v1beta1`;
 

--- a/tests/github/api/api-client.service.ts
+++ b/tests/github/api/api-client.service.ts
@@ -21,7 +21,7 @@ type APIHttpOptions = HttpOptions & {
 @Injectable()
 export class APIClient {
 
-  readonly options: APIHttpOptions;
+  private readonly options: APIHttpOptions;
 
   private readonly domain: string = `https://api.github.com`;
 


### PR DESCRIPTION
Compilation with ngc fails with next error
error TS4031: Public property 'options' of exported class has or is using private name 'APIHttpOptions'.
If options property needs to be public type APIHttpOptions  should be exported.