### PR TITLE
fix(generator): Expose error from spec validation

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -29,7 +29,7 @@ export async function generateAPIClient(options: GenOptions): Promise<string[]> 
       }
     });
   } catch (error) {
-    throw new Error(`Provided swagger file "${swaggerFilePath}" is invalid`);
+    throw new Error(`Provided swagger file "${swaggerFilePath}" is invalid: ${error}`);
   }
 
   const swaggerDef: Swagger = await swaggerFile(swaggerFilePath);


### PR DESCRIPTION
The error from validating the spec is suppressed. In my case, it was due to an extra path parameter.
